### PR TITLE
Enforce no rawtypes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.maven.compiler.plugin}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Werror</arg>
+                        <arg>-Xlint:rawtypes</arg>
+                    </compilerArgs>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -223,7 +236,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <reporting>
         <plugins>
             <plugin>

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -2,6 +2,7 @@ New in 1.7.12
     Many minor code improvements
     Minor fixes for performance test
     Now uses Spring 3.2.6
+    Added `HierarchicalInfileObjectLoader#setIgnoredClasses`; deprecated `HierarchicalInfileObjectLoader#setClassesToIgnore`
 
 New in 1.7.11
     Added greater precision when persisting float values

--- a/src/main/java/com/opower/persistence/jpile/infile/InfileDataBuffer.java
+++ b/src/main/java/com/opower/persistence/jpile/infile/InfileDataBuffer.java
@@ -3,6 +3,7 @@ package com.opower.persistence.jpile.infile;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.opower.persistence.jpile.reflection.CachedProxy;
 import com.opower.persistence.jpile.reflection.PersistenceAnnotationInspector;
 import org.joda.time.format.DateTimeFormat;
@@ -25,7 +26,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableSet.of;
 
 /**
  * A buffer used to collect data in MySQL's infile format. This buffer also maintains a separate row buffer
@@ -62,8 +62,14 @@ public class InfileDataBuffer implements InfileRow {
     protected static final String MYSQL_NULL_STRING = MYSQL_ESCAPE_CHAR + "N";
     // List of bytes that will need escaping as they hold special meaning to MYSQL
     // See http://dev.mysql.com/doc/refman/5.1/en/load-data.html
-    protected static final Set<Byte> BYTES_NEEDING_ESCAPING =
-            of((byte) '\0', (byte) '\b', (byte) '\n', (byte) '\r', (byte) '\t', (byte) MYSQL_ESCAPE_CHAR, (byte) 26);
+    protected static final Set<Byte> BYTES_NEEDING_ESCAPING = ImmutableSet.of(
+            (byte) '\0',
+            (byte) '\b',
+            (byte) '\n',
+            (byte) '\r',
+            (byte) '\t',
+            (byte) MYSQL_ESCAPE_CHAR,
+            (byte) 26);
     private static final String TEMPORAL_TYPE_EXCEPTION =
             "The Temporal.value should be TemporalType.DATE, TemporalType.TIME, or TemporalType.TIMESTAMP on method [%s]";
     // This Pattern matches on all of the BYTES_NEEDING_ESCAPING

--- a/src/main/java/com/opower/persistence/jpile/infile/driver/C3P0JdbcDriverSupport.java
+++ b/src/main/java/com/opower/persistence/jpile/infile/driver/C3P0JdbcDriverSupport.java
@@ -21,7 +21,7 @@ public class C3P0JdbcDriverSupport implements InfileStatementCallback.JdbcDriver
     // of the method on the MySQL statement that we invoke via reflection.
     private static final String INFILE_MUTATOR_METHOD = "setLocalInfileInputStream";
 
-    private static Class targetInterface;
+    private static Class<?> targetInterface;
 
     static {
         try {

--- a/src/main/java/com/opower/persistence/jpile/loader/HierarchicalInfileObjectLoader.java
+++ b/src/main/java/com/opower/persistence/jpile/loader/HierarchicalInfileObjectLoader.java
@@ -2,6 +2,7 @@ package com.opower.persistence.jpile.loader;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.opower.persistence.jpile.infile.InfileDataBuffer;
 import com.opower.persistence.jpile.reflection.CachedProxy;
@@ -28,8 +29,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Throwables.propagate;
-import static com.google.common.collect.ImmutableList.copyOf;
-import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Maps.newLinkedHashMap;
@@ -80,7 +79,7 @@ public class HierarchicalInfileObjectLoader implements Flushable, Closeable {
      * @param moreObjects optional more objects
      */
     public void persist(Object firstObject, Object... moreObjects) {
-        persist(concat(of(firstObject), copyOf(moreObjects)));
+        persist(concat(ImmutableList.of(firstObject), ImmutableList.copyOf(moreObjects)));
     }
 
     /**

--- a/src/main/java/com/opower/persistence/jpile/reflection/CachedProxy.java
+++ b/src/main/java/com/opower/persistence/jpile/reflection/CachedProxy.java
@@ -69,12 +69,12 @@ public final class CachedProxy {
     public static <T> T create(final T impl) {
         ProxyFactory factory = new ProxyFactory();
         factory.setSuperclass(impl.getClass());
-        Class cachedClass = factory.createClass();
+        @SuppressWarnings("unchecked")
+        Class<? extends T> cachedClass = factory.createClass();
         try {
-            @SuppressWarnings("unchecked")
-            T cachedInstance = (T) cachedClass.newInstance();
+            T cachedInstance = cachedClass.newInstance();
             ((ProxyObject) cachedInstance).setHandler(new MethodHandler() {
-                final LoadingCache<Args, Optional> cache = createCache(impl);
+                final LoadingCache<Args, Optional<Object>> cache = createCache(impl);
 
                 /**
                  * Returns the cached value of this method. If the method returns null then null is returned.
@@ -93,12 +93,12 @@ public final class CachedProxy {
         }
     }
 
-    private static LoadingCache<Args, Optional> createCache(final Object impl) {
+    private static LoadingCache<Args, Optional<Object>> createCache(final Object impl) {
         return CacheBuilder.newBuilder()
                            .softValues()
-                           .build(new CacheLoader<Args, Optional>() {
+                           .build(new CacheLoader<Args, Optional<Object>>() {
                                @Override
-                               public Optional load(@Nonnull Args key)
+                               public Optional<Object> load(@Nonnull Args key)
                                        throws InvocationTargetException, IllegalAccessException {
                                    return Optional.fromNullable(key.method.invoke(impl, key.args));
                                }

--- a/src/main/java/com/opower/persistence/jpile/reflection/PersistenceAnnotationInspector.java
+++ b/src/main/java/com/opower/persistence/jpile/reflection/PersistenceAnnotationInspector.java
@@ -17,8 +17,6 @@ import com.google.common.collect.Iterables;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ReflectionUtils;
 
-import static com.google.common.collect.ImmutableList.copyOf;
-import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.Lists.newArrayList;
 
 /**
@@ -136,10 +134,10 @@ public class PersistenceAnnotationInspector {
         SecondaryTable secondaryTable = findAnnotation(aClass, SecondaryTable.class);
         SecondaryTables secondaryTables = findAnnotation(aClass, SecondaryTables.class);
         if (secondaryTables != null) {
-            annotations = copyOf(secondaryTables.value());
+            annotations = ImmutableList.copyOf(secondaryTables.value());
         }
         else if (secondaryTable != null) {
-            annotations = of(secondaryTable);
+            annotations = ImmutableList.of(secondaryTable);
         }
         return annotations;
     }
@@ -310,7 +308,7 @@ public class PersistenceAnnotationInspector {
      * @return the list of methods
      */
     public List<Method> methodsAnnotatedWith(Class<?> aClass, Predicate<Method> predicate) {
-        return newArrayList(Iterables.filter(copyOf(ReflectionUtils.getAllDeclaredMethods(aClass)), predicate));
+        return newArrayList(Iterables.filter(ImmutableList.copyOf(ReflectionUtils.getAllDeclaredMethods(aClass)), predicate));
     }
 
     /**

--- a/src/main/java/com/opower/persistence/jpile/reflection/PersistenceAnnotationInspector.java
+++ b/src/main/java/com/opower/persistence/jpile/reflection/PersistenceAnnotationInspector.java
@@ -202,7 +202,7 @@ public class PersistenceAnnotationInspector {
         Preconditions.checkNotNull(getter, "Cannot find setter from null getter");
         checkGetterPreconditions(getter);
 
-        Class aClass = getter.getDeclaringClass();
+        Class<?> aClass = getter.getDeclaringClass();
         String getterPrefix = getGetterPrefix(getter);
 
         String setterName = getter.getName().replaceFirst(getterPrefix, SETTER_PREFIX);
@@ -221,7 +221,7 @@ public class PersistenceAnnotationInspector {
         Preconditions.checkState(setter.getParameterTypes().length == 1, "Setter must have just one parameter");
         Preconditions.checkState(setter.getName().startsWith(SETTER_PREFIX), "Setter must start with %s", SETTER_PREFIX);
 
-        Class aClass = setter.getDeclaringClass();
+        Class<?> aClass = setter.getDeclaringClass();
 
         Method getter = ReflectionUtils.findMethod(aClass, setter.getName().replaceFirst(SETTER_PREFIX, GETTER_PREFIX));
 
@@ -242,7 +242,7 @@ public class PersistenceAnnotationInspector {
     public Field fieldFromGetter(Method getter) {
         Preconditions.checkNotNull(getter, "Cannot find field from null getter");
         checkGetterPreconditions(getter);
-        Class aClass = getter.getDeclaringClass();
+        Class<?> aClass = getter.getDeclaringClass();
 
         String getterName = getter.getName();
         String getterPrefix = getGetterPrefix(getter);

--- a/src/test/java/com/opower/persistence/jpile/AbstractIntTestForJPile.java
+++ b/src/test/java/com/opower/persistence/jpile/AbstractIntTestForJPile.java
@@ -1,6 +1,7 @@
 package com.opower.persistence.jpile;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.opower.persistence.jpile.loader.HierarchicalInfileObjectLoader;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -18,8 +19,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.of;
-
 /**
  * Abstract test case for all int tests. Loads MySQL drivers and creates a new MySQL {@link Connection}
  *
@@ -29,7 +28,8 @@ import static com.google.common.collect.ImmutableList.of;
 @ContextConfiguration
 public abstract class AbstractIntTestForJPile {
     private static final String JDBC_URL = "jdbc:mysql://localhost/jpile?useUnicode=true&characterEncoding=utf-8";
-    private static final List<String> TABLES = of("customer", "product", "contact", "contact_phone", "binary_data", "supplier");
+    private static final List<String> TABLES =
+            ImmutableList.of("customer", "product", "contact", "contact_phone", "binary_data", "supplier");
     private static final String DB_USER = "root";
     private static final String DB_PASSWORD = "";
 

--- a/src/test/java/com/opower/persistence/jpile/loader/IntTestHierarchicalInfileObjectLoader.java
+++ b/src/test/java/com/opower/persistence/jpile/loader/IntTestHierarchicalInfileObjectLoader.java
@@ -144,8 +144,19 @@ public class IntTestHierarchicalInfileObjectLoader extends AbstractIntTestForJPi
     }
 
     @Test
-    public void testIgnore() {
+    @SuppressWarnings({"rawtypes", "deprecation"}) // Testing deprecated method
+    public void testClassesToIgnore() {
         this.hierarchicalInfileObjectLoader.setClassesToIgnore(ImmutableSet.<Class>of(Customer.class));
+
+        Customer customer = ObjectFactory.newCustomer();
+        this.hierarchicalInfileObjectLoader.persist(customer);
+
+        assertNull(customer.getId());
+    }
+
+    @Test
+    public void testIgnoredClasses() {
+        this.hierarchicalInfileObjectLoader.setIgnoredClasses(ImmutableSet.<Class<?>>of(Customer.class));
 
         Customer customer = ObjectFactory.newCustomer();
         this.hierarchicalInfileObjectLoader.persist(customer);

--- a/src/test/java/com/opower/persistence/jpile/reflection/PersistenceAnnotationInspectorTest.java
+++ b/src/test/java/com/opower/persistence/jpile/reflection/PersistenceAnnotationInspectorTest.java
@@ -10,12 +10,12 @@ import javax.persistence.SecondaryTables;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 
+import com.google.common.collect.ImmutableList;
 import com.opower.persistence.jpile.sample.Contact;
 import com.opower.persistence.jpile.sample.Customer;
 import com.opower.persistence.jpile.sample.Product;
 import org.junit.Test;
 
-import static com.google.common.collect.ImmutableList.copyOf;
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -157,7 +157,7 @@ public class PersistenceAnnotationInspectorTest {
     @Test
     public void testFindSecondaryTableAnnotations() throws Exception {
         assertEquals(
-                copyOf(Contact.class.getAnnotation(SecondaryTables.class).value()),
+                ImmutableList.copyOf(Contact.class.getAnnotation(SecondaryTables.class).value()),
                 annotationInspector.findSecondaryTables(Contact.class)
         );
     }


### PR DESCRIPTION
Enforce no rawtypes; fix occurrences.

This is goes along with similar changes being made to a consuming library.

- Added `HierarchicalInfileObjectLoader#setIgnoredClasses(Set<Class<?>>)`
- Deprecated `HierarchicalInfileObjectLoader#setClassesToIgnore(Set<Class>)`