### PR TITLE
Fix several design issues related to DataSourceBasedStatementExecutor class

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,7 @@
+New in 1.8.2
+    Remove side-effect in constructor of `DataSourceBasedStatementExecutor`. Lazily initialize connection before call to `execute` method
+    FIXED possible connection leak in `DataSourceBasedStatementExecutor` class.
+
 New in 1.8.1
     Reintroduce and deprecate the API removed in 1.8.0 release
 

--- a/src/main/java/com/opower/persistence/jpile/jdbc/DataSourceBasedStatementExecutor.java
+++ b/src/main/java/com/opower/persistence/jpile/jdbc/DataSourceBasedStatementExecutor.java
@@ -2,67 +2,137 @@ package com.opower.persistence.jpile.jdbc;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 import java.sql.SQLException;
 
 /**
- * This implementation operates the {@link DataSource}. It creates a
- * {@link ConnectionBasedStatementExecutor} using {@link java.sql.Connection}
- * from {@link DataSource} and delegates all calls to it.
- * <p/>
- * This implementation has no mechanism to process failures from underlying
- * {@link ConnectionBasedStatementExecutor} and retry execution with another
- * {@link java.sql.Connection}. If you need such behavior then create a subclass.
- * <p/>
- * Be aware that this implementation is not thread-safe.
+ * <p>
+ *  This implementation operates the {@link DataSource}. It creates a
+ *  {@link ConnectionBasedStatementExecutor} using {@link java.sql.Connection}
+ *  from {@link DataSource} and delegates all calls to it.
+ * </p>
+ * <p>
+ *  Be aware that this implementation is not thread-safe.
+ * </p>
  *
  * @author ivan.german
  */
 public class DataSourceBasedStatementExecutor implements StatementExecutor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceBasedStatementExecutor.class);
 
     private ConnectionBasedStatementExecutor connectionBasedStatementExecutor;
     private final DataSource dataSource;
 
-    public DataSourceBasedStatementExecutor(DataSource dataSource) throws SQLException {
+    public DataSourceBasedStatementExecutor(DataSource dataSource) {
         Preconditions.checkNotNull(dataSource, "dataSource must not be null");
 
         this.dataSource = dataSource;
-        initNewConnection();
     }
 
     /**
-     * {@inheritDoc}
+     * <p>
+     *  Processes {@link StatementCallback} in context of used connection.
+     *  If this {@link StatementExecutor} don't own any open connection then new one
+     *  is requested from the data source.
+     * </p>
+     * <p>
+     *  Be aware that foreign key constraints are disabled for used connection.
+     * </p>
+     *
+     * @throws RuntimeException if any problem occur during execution
+     * @return result of {@link StatementCallback}
      */
     @Override
     public <T> T execute(StatementCallback<T> statementCallback) {
-        Preconditions.checkNotNull(
-                this.connectionBasedStatementExecutor, "underlying connectionBasedStatementExecutor is null");
+        try {
+            if (this.connectionBasedStatementExecutor == null) {
+                initNewConnection();
+            }
 
-        return this.connectionBasedStatementExecutor.execute(statementCallback);
+            return this.connectionBasedStatementExecutor.execute(statementCallback);
+        }
+        /* Propagated exception */
+        catch (Exception e) {
+            try {
+                shutdown();
+            }
+            catch (Exception shutdownException) {
+                e.addSuppressed(shutdownException);
+            }
+
+            throw Throwables.propagate(e);
+        }
     }
 
     /**
-     * {@inheritDoc}
+     * Re-enables foreign key constraints for owned connection and returns it
+     * back to connection pool.
+     *
+     * @throws RuntimeException if any error occur during execution
      */
     @Override
     public void shutdown() {
         if (this.connectionBasedStatementExecutor != null) {
-            this.connectionBasedStatementExecutor.shutdown();
-            this.connectionBasedStatementExecutor.closeConnection();
-            this.connectionBasedStatementExecutor = null;
+            try {
+                this.connectionBasedStatementExecutor.shutdown();
+            }
+            /* Propagated exception should be logged and rethrown */
+            catch (Exception e) {
+                LOGGER.warn("Fail to re-enable foreign key constraints", e);
+                throw Throwables.propagate(e);
+            }
+            finally {
+                this.connectionBasedStatementExecutor.closeConnection();
+                this.connectionBasedStatementExecutor = null;
+            }
         }
     }
 
     /**
-     * Ensure that previous connection is closed and open new one.
+     * <p>
+     *   Ensure that previous connection is closed and open new one.
+     * </p>
+     *
+     * @throws RuntimeException if any problem occur
      */
     public void initNewConnection() {
+        Connection connection = null;
+
         try {
-            shutdown();
-            this.connectionBasedStatementExecutor = new ConnectionBasedStatementExecutor(dataSource.getConnection());
+            try {
+                shutdown();
+            }
+            catch (RuntimeException ignoredException) {
+                /*
+                 * Exception from shutdown is already printed. Connection is returned to pool.
+                 * So basically nothing restricts us from opening new connection.
+                 */
+            }
+
+            connection = this.dataSource.getConnection();
+            this.connectionBasedStatementExecutor = new ConnectionBasedStatementExecutor(connection);
         }
-        catch (SQLException e) {
+        /**
+         * Exceptions propagated from {@link ConnectionBasedStatementExecutor}
+         * and exception from {@link DataSource#getConnection()}
+         */
+        catch (Exception e) {
+            LOGGER.error("Fail to init new connection", e);
+
+            try {
+                if (connection != null) {
+                    connection.close();
+                }
+            }
+            catch (SQLException closeException) {
+                LOGGER.error("Fail to close connection", e);
+                e.addSuppressed(closeException);
+            }
+
             throw Throwables.propagate(e);
         }
     }

--- a/src/test/java/com/opower/persistence/jpile/jdbc/TestDataSourceBasedStatementExecutor.java
+++ b/src/test/java/com/opower/persistence/jpile/jdbc/TestDataSourceBasedStatementExecutor.java
@@ -1,0 +1,269 @@
+package com.opower.persistence.jpile.jdbc;
+
+import com.google.common.base.Throwables;
+import org.junit.Test;
+import org.mockito.stubbing.OngoingStubbing;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test to check that {@link DataSourceBasedStatementExecutor} works correctly.
+ *
+ * @author ivan.german
+ */
+public class TestDataSourceBasedStatementExecutor {
+
+    private final Exception failureException = new SQLException("Expected failure exception");
+
+    /**
+     * Create {@link DataSourceBasedStatementExecutor} and execute statement on it.
+     * Expected actions:
+     * <ol>
+     *     <li>Init new connection</li>
+     *     <li>Execute statement</li>
+     *     <li>Connection should <b>not</b> be closed at the end</li>
+     * </ol>
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testExecute() throws SQLException {
+        Statement disableFkStatement = mockStatement(true);
+        Statement statement = mockStatement(true);
+        Connection connection = mockConnection(disableFkStatement, statement);
+
+        DataSource dataSource = mockDataSource(connection);
+
+        DataSourceBasedStatementExecutor executor = new DataSourceBasedStatementExecutor(dataSource);
+        executor.execute(new MockStatementCallback());
+
+        verify(disableFkStatement).close();
+        verify(statement).close();
+
+        /* Last statement was successful so connection will be reused */
+        verify(connection, never()).close();
+    }
+
+    /**
+     * Create {@link DataSourceBasedStatementExecutor} and execute two statements on it.
+     * Expected actions:
+     * <ol>
+     *     <li>Init new connection</li>
+     *     <li>Execute statement1</li>
+     *     <li>Execute statement2 using the same connection</li>
+     *     <li>Connection should <b>not</b> be closed at the end</li>
+     * </ol>
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testExecuteSeveralStatements() throws SQLException {
+        Statement disableFkStatement = mockStatement(true);
+        Statement statement1 = mockStatement(true);
+        Statement statement2 = mockStatement(true);
+
+        Connection connection = mockConnection(disableFkStatement, statement1, statement2);
+
+        DataSource dataSource = mockDataSource(connection);
+
+        DataSourceBasedStatementExecutor executor = new DataSourceBasedStatementExecutor(dataSource);
+        executor.execute(new MockStatementCallback());
+        executor.execute(new MockStatementCallback());
+
+        verify(disableFkStatement).close();
+        verify(statement1).close();
+        verify(statement2).close();
+
+        /* Last statement was successful so connection will be reused */
+        verify(connection, never()).close();
+    }
+
+    /**
+     * Create {@link DataSourceBasedStatementExecutor}, execute statement on it, shut it down and execute another statement.
+     * Expected actions:
+     * <ol>
+     *     <li>Init new connection</li>
+     *     <li>Execute statement</li>
+     *     <li>Close connection</li>
+     *     <li>Init new connection</li>
+     *     <li>Execute second statement</li>
+     *     <li>Connection should <b>not</b> be closed at the end</li>
+     * </ol>
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void testExecuteThenShutdownThenExecute() throws SQLException {
+        Statement disableFkStatement1 = mockStatement(true);
+        Statement statement1 = mockStatement(true);
+        Statement enableFkStatement1 = mockStatement(true);
+        Connection connection1 = mockConnection(disableFkStatement1, statement1, enableFkStatement1);
+
+        Statement disableFkStatement2 = mockStatement(true);
+        Statement statement2 = mockStatement(true);
+        Connection connection2 = mockConnection(disableFkStatement2, statement2);
+
+        DataSource dataSource = mockDataSource(connection1, connection2);
+
+        DataSourceBasedStatementExecutor executor = new DataSourceBasedStatementExecutor(dataSource);
+
+        executor.execute(new MockStatementCallback());
+        executor.shutdown();
+
+        verify(disableFkStatement1).close();
+        verify(statement1).close();
+        verify(enableFkStatement1).close();
+        verify(connection1).close();
+
+        executor.execute(new MockStatementCallback());
+
+        verify(disableFkStatement2).close();
+        verify(statement2).close();
+
+        /* Last statement was successful so connection will be reused */
+        verify(connection2, never()).close();
+    }
+
+    /**
+     * Check that connection is returned to pool if it fails to initialize (disable foreign key constraints).
+     *
+     * @throws Throwable
+     */
+    @Test
+    public void testDisableForeignKeysFailure() throws Throwable {
+        Statement disableFkStatement = mockStatement(false);
+        Connection connection = mockConnection(disableFkStatement);
+
+        DataSource dataSource = mockDataSource(connection);
+
+        try {
+            DataSourceBasedStatementExecutor executor = new DataSourceBasedStatementExecutor(dataSource);
+            executor.execute(new MockStatementCallback());
+        }
+        catch (RuntimeException e) {
+            assertEquals(this.failureException, Throwables.getRootCause(e));
+        }
+        finally {
+            verify(disableFkStatement).close();
+            verify(connection).close();
+        }
+    }
+
+    /**
+     * Check that connection is closed if it fails to execute statement.
+     *
+     * @throws Throwable
+     */
+    @Test
+    public void testExecutionFailure() throws Throwable {
+        Statement disableFkStatement = mockStatement(true);
+        Statement statement = mockStatement(false);
+        Statement enableFkStatement = mockStatement(true);
+
+        Connection connection = mockConnection(disableFkStatement, statement, enableFkStatement);
+
+        DataSource dataSource = mockDataSource(connection);
+
+        try {
+            DataSourceBasedStatementExecutor executor = new DataSourceBasedStatementExecutor(dataSource);
+            executor.execute(new MockStatementCallback());
+        }
+        catch (RuntimeException e) {
+            assertEquals(this.failureException, Throwables.getRootCause(e));
+        }
+        finally {
+            verify(disableFkStatement).close();
+            verify(statement).close();
+            verify(enableFkStatement).close();
+            verify(connection).close();
+        }
+    }
+
+    /**
+     * Check that connection is closed if it fails to execute statement and re-enable foreign key constraints.
+     * Also check that exception from {@link DataSourceBasedStatementExecutor#execute(StatementCallback)}
+     * is passed to the caller instead of exception from {@link DataSourceBasedStatementExecutor#shutdown()}
+     *
+     * @throws Throwable
+     */
+    @Test
+    public void testReEnableForeignKeysFailure() throws Throwable {
+        Statement disableFkStatement = mockStatement(true);
+        Statement statement = mockStatement(false);
+        Statement enableFkStatement = mockStatement(false, new SQLException("Exception during re-enabling of foreign keys"));
+
+        Connection connection = mockConnection(disableFkStatement, statement, enableFkStatement);
+
+        DataSource dataSource = mockDataSource(connection);
+
+        try {
+            DataSourceBasedStatementExecutor executor = new DataSourceBasedStatementExecutor(dataSource);
+            executor.execute(new MockStatementCallback());
+        }
+        catch (RuntimeException e) {
+            assertEquals(this.failureException, Throwables.getRootCause(e));
+        }
+        finally {
+            verify(disableFkStatement).close();
+            verify(statement).close();
+            verify(enableFkStatement).close();
+            verify(connection).close();
+        }
+    }
+
+    private Statement mockStatement(boolean successful) throws SQLException {
+        return mockStatement(successful, this.failureException);
+    }
+
+    private Statement mockStatement(boolean successful, Exception thrownException) throws SQLException {
+        Statement result = mock(Statement.class);
+
+        if (successful) {
+            when(result.execute(anyString())).thenReturn(true);
+        }
+        else {
+            when(result.execute(anyString())).thenThrow(thrownException);
+        }
+
+        return result;
+    }
+
+    private Connection mockConnection(Statement... statements) throws SQLException {
+        Connection result = mock(Connection.class);
+
+        OngoingStubbing<Statement> expectedCall = when(result.createStatement());
+        for (Statement statement : statements) {
+            expectedCall = expectedCall.thenReturn(statement);
+        }
+
+        return result;
+    }
+
+    private DataSource mockDataSource(Connection... connections) throws SQLException {
+        DataSource result = mock(DataSource.class);
+
+        OngoingStubbing<Connection> expectedCall = when(result.getConnection());
+        for (Connection connection : connections) {
+            expectedCall = expectedCall.thenReturn(connection);
+        }
+
+        return result;
+    }
+
+    private class MockStatementCallback implements StatementCallback<Boolean> {
+        @Override
+        public Boolean doInStatement(Statement statement) throws SQLException {
+            return statement.execute("");
+        }
+    }
+}


### PR DESCRIPTION
Trying to implement advanced ```StatementExecutor``` using ```DataSourceBasedStatementExecutor``` we have encountered several design issues of this class.

1. Queries that disable/enable foreign key constraints can become a source of connection leaks because there was no code to handle failures that might happen in these queries.
2. Side-effect in constructor (```DataSource.getConnection()```) make it difficult to test subclasses and wrappers for this class.

Here are the fixes for found issues:
1. Guarantee that connections are closed.
2. Remove side-effect from constructor. Lazily initialize connection before call to execute.
3. Expand both unit and integration test sets for ```DataSourceBasedStatementExecutor```.