### PR TITLE
Integration tests now support overriding database properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,29 @@ jPile allows the client to configure whether entities are updated when inserting
 
 # How do I run the tests?
 
-jPile needs a local MySQL running and Apache Maven. Create a new database schema called 'jpile' using `CREATE DATABASE jpile CHARACTER SET utf8 COLLATE utf8_general_ci`. The test classes use `root` with no password to login. The username and password is located in `AbstractIntTestForJPile` class.
+jPile needs a local MySQL running and Apache Maven.
+Create a new database schema called 'jpile' using `CREATE DATABASE jpile CHARACTER SET utf8 COLLATE utf8_general_ci`.
+By default, the test classes use `root` with no password to login.
+You can change these settings via the following properties:
+
+<table>
+  <tr>
+    <th>Property</th>
+    <th>Default Value</th>
+  </tr>
+  <tr>
+    <td>testing.jdbc.url</td>
+    <td>jdbc:mysql://localhost/jpile?useUnicode=true&characterEncoding=utf-8</td>
+  </tr>
+  <tr>
+    <td>testing.jdbc.username</td>
+    <td>root</td>
+  </tr>
+  <tr>
+    <td>testing.jdbc.password</td>
+    <td>""</td>
+  </tr>
+</table>
 
 All test cases will automatically create and drop the required tables for integration tests. After creating the local database, you should be able to run `mvn clean install` to run all the tests and install locally.
 

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,6 @@
+New in 1.8.3
+    Integration tests now support testing.jdbc.user, testing.jdbc.password, testing.jdbc.url properties
+
 New in 1.8.2
     Remove side-effect in constructor of `DataSourceBasedStatementExecutor`. Lazily initialize connection before call to `execute` method
     FIXED possible connection leak in `DataSourceBasedStatementExecutor` class.

--- a/src/test/java/com/opower/persistence/jpile/util/JdbcTestUtil.java
+++ b/src/test/java/com/opower/persistence/jpile/util/JdbcTestUtil.java
@@ -13,9 +13,9 @@ import java.sql.SQLException;
  */
 public final class JdbcTestUtil {
 
-    private static final String JDBC_URL = "jdbc:mysql://localhost/jpile?useUnicode=true&characterEncoding=utf-8";
-    private static final String DB_USER = "root";
-    private static final String DB_PASSWORD = "";
+    private static final String DEFAULT_JDBC_URL = "jdbc:mysql://localhost/jpile?useUnicode=true&characterEncoding=utf-8";
+    private static final String DEFAULT_DB_USER = "root";
+    private static final String DEFAULT_DB_PASSWORD = "";
 
     static {
         try {
@@ -38,6 +38,9 @@ public final class JdbcTestUtil {
      * @throws SQLException if connection failed to open
      */
     public static Connection openNewConnection() throws SQLException {
-        return DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASSWORD);
+        return DriverManager.getConnection(
+                System.getProperty("testing.jdbc.url", DEFAULT_JDBC_URL),
+                System.getProperty("testing.jdbc.user", DEFAULT_DB_USER),
+                System.getProperty("testing.jdbc.password", DEFAULT_DB_PASSWORD));
     }
 }


### PR DESCRIPTION
New properties are:
- `testing.jdbc.user`
- `testing.jdbc.password`
- `testing.jdbc.url`